### PR TITLE
PHP 8/php-generator v4 compatibility update

### DIFF
--- a/src/HttpAuthExtension/HttpAuthExtension.php
+++ b/src/HttpAuthExtension/HttpAuthExtension.php
@@ -40,7 +40,7 @@ final class HttpAuthExtension extends CompilerExtension
 		$config = $this->config;
 
 		if (isset($config->username, $config->password, $config->title)) {
-            $initialize = $class->getMethod('initialize');
+			$initialize = $class->getMethod('initialize');
 
 			$initialize->addBody('$auth = new HttpAuthExtension\HttpAuthenticator( $this->getByType(\'Nette\Http\IResponse\'), ?, ?, ? );',
 					[$config->username, $config->password, $config->title]);

--- a/src/HttpAuthExtension/HttpAuthExtension.php
+++ b/src/HttpAuthExtension/HttpAuthExtension.php
@@ -40,7 +40,7 @@ final class HttpAuthExtension extends CompilerExtension
 		$config = $this->config;
 
 		if (isset($config->username, $config->password, $config->title)) {
-			$initialize = $class->methods['initialize'];
+            $initialize = $class->getMethod('initialize');
 
 			$initialize->addBody('$auth = new HttpAuthExtension\HttpAuthenticator( $this->getByType(\'Nette\Http\IResponse\'), ?, ?, ? );',
 					[$config->username, $config->password, $config->title]);


### PR DESCRIPTION
PhpGenerator\ClassType.php was refactored in v.4, so $methods-property became private. Fixed by using $class->getMethod('initialize') instead.